### PR TITLE
step: update links to NZTC challenge

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -8,9 +8,9 @@ Welome to RangL, a competition platform to accelerate progress in data-driven co
 
 We are currently working on the challenge:
 
-1. [Net Zero Technology Centre (NZTC)](http://challenges.rangl.org/web/challenges/challenge-page/8/overview)
+1. [Net Zero Technology Centre (NZTC)](https://challenges.rangl.org/web/challenges/challenge-page/1/overview)
 
 But we also have a number of past challenges:
 
-1. [Generation scheduling](http://challenges.rangl.org/web/challenges/challenge-page/1/overview)
+1. Generation scheduling
 2. [Vehicle grid integration](challenges/vgi.md)

--- a/src/components/HomepageFeatures.js
+++ b/src/components/HomepageFeatures.js
@@ -7,14 +7,14 @@ const featureList = [
   {
     title: "Generation Scheduling",
     imageURL: "img/wind.jpg",
-    link: "http://challenges.rangl.org/web/challenges/challenge-page/1/overview",
+    link: null,
     current: false,
     description: <>Schedule a power system to run super-efficiently.</>,
   },
   {
     title: "Pathways to Net Zero",
     imageURL: "img/nztc.jpg",
-    link: "http://challenges.rangl.org/web/challenges/challenge-page/8/overview",
+    link: "https://challenges.rangl.org/web/challenges/challenge-page/1/overview",
     current: true,
     description: <>Find the optimal pathway to a carbon neutral 2050.</>,
   },
@@ -38,9 +38,9 @@ function Feature({ imageURL, title, link, description }) {
         </a>
       </div>
       <div className="text--center padding-horiz--md">
-        <a href={link} target="_blank">
+        {link ? <a href={link} target="_blank">
           <h3>{title}</h3>
-        </a>
+        </a> : <h3>{title}</h3>}
         <p>{description}</p>
       </div>
     </div>


### PR DESCRIPTION
This pull request:

1. Updates links to the NZTC challenge: https://challenges.rangl.org/web/challenges/challenge-page/1/overview
2. Removes links to the generation scheduling challenge. We will need to restore this challenge to the EvalAI platform, then add the link back in.